### PR TITLE
Add the CONTRIBUTING.md file to the agenda

### DIFF
--- a/meetings/2020-01-28.md
+++ b/meetings/2020-01-28.md
@@ -22,6 +22,7 @@ To attend this meeting or propose a topic, edit this page and add your name to t
 
 ### Agenda
 - Code of Conduct Approval: https://github.com/prestodb/tsc/pull/11
+- Approve default CONTRIBUTING.md: https://github.com/prestodb/.github/pull/1
 - Separation of TSC & committers, finalize process
 
 ### Attendees


### PR DESCRIPTION
This PR adds approval of the current CONTRIBUTING.md file to the agenda, found at https://github.com/prestodb/.github/blob/add-contributing/CONTRIBUTING.md

Signed-off-by: Brian Warner <brian@bdwarner.com>