### PR TITLE
Add agenda for Feb 11 meeting

### DIFF
--- a/meetings/2020-02-11.md
+++ b/meetings/2020-02-11.md
@@ -1,6 +1,6 @@
 # Presto TSC Meeting
 
-### 2020-02-20
+### 2020-02-11
 ##### 9:00 AM PST to 10:30 AM PST
 
 ##### Community Calendar
@@ -45,5 +45,4 @@ To attend this meeting or propose a topic, edit this page and add your name to t
 #### Attendees
 
 #### Not present
-
 

--- a/meetings/2020-02-11.md
+++ b/meetings/2020-02-11.md
@@ -1,0 +1,49 @@
+# Presto TSC Meeting
+
+### 2020-02-20
+##### 9:00 AM PST to 10:30 AM PST
+
+##### Community Calendar
+[Here](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_vrjlva5b0u73ps75fvnv5sasi4%40group.calendar.google.com&ctz=America%2FChicago) is the public calendar for the Presto TSC meetings.
+
+##### How to Join
+TSC meetings are open for all to join.
+
+https://zoom.us/j/762982927
+
+##### Agenda and Attending this meeting
+
+To attend this meeting or propose a topic, edit this page and add your name to the list of attendees below along with your organization and location. Add any agenda item you wish to discuss, please include relevant links.
+
+* This meeting is for the members of the technical steering committee for Presto + wider community.
+* To cover everything, discussion may be time-constrained per topic.
+* Topics that require less discussion should be covered first.
+* To respect meeting size, topics should be relevant to the agenda.
+
+### Agenda
+- FYI PrestoCon + CFP closes Feb 7th: https://events.linuxfoundation.org/prestocon/
+- Uber representative on TSC
+- Code of Conduct Approval: https://github.com/prestodb/tsc/pull/11
+- Approve default CONTRIBUTING.md: https://github.com/prestodb/.github/pull/1
+  - Discuss deprecating overlapping content in the wiki
+- Discuss [changes to tsc README.md](https://github.com/prestodb/tsc/pull/28)
+  - Terms of TSC members
+  - Who is eligible to be a TSC member
+  - Nominating procedures
+  - Election procedures
+  - Replacement procedures
+- New additions to CHARTER.md
+  - Clarify quorum rules (e.g., members who miss _n_ consecutive meetings don't count toward quorum)?
+  - Set a maximum number of TSC members
+  - Create a few governing board-appointed seats for bidirectional representation?
+- Rename mailing lists: presto-community -> presto-user, and presto-tsc -> presto-dev
+
+### Attendance
+#### Voting members
+
+
+#### Attendees
+
+#### Not present
+
+


### PR DESCRIPTION
This agenda includes reviews of the docs proposed in the last call, as well as a topic on Uber representation on the TSC.

Signed-off-by: Brian Warner <brian@bdwarner.com>