### PR TITLE
Update current TSC members and election process

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -77,36 +77,7 @@ c. Except as provided in Section 2.j, 8.c. and 9.a, decisions by vote at a meeti
 
 d. In the event a vote cannot be resolved by the TSC, any voting member of the TSC may refer the matter to the Governing Board or the Series Manager for assistance in reaching a resolution.
 
-e. The legacy voting members are:
-
-| Name              | Github                                            | Term End           |
-| ----------------- | ------------------------------------------------- | ------------------ |
-| Masha Basmanova   |[mbasmanova](https://github.com/mbasmanova)        | October 31, 2021   |
-| Zhenxiao Luo      |[zhenxiao](https://github.com/zhenxiao)            | October 31, 2021   |
-| Andrii Rosa       |[arhimondr](https://github.com/arhimondr)          | October 31, 2021   |
-| Rebecca Schlussel |[rschlussel](https://.github.com/rschlussel)       | October 31, 2021   |
-| James Sun         |[highker](https://github.com/highker)              | October 31, 2021   |
-| Wenlei Xie        |[wenleix](https://github.com/wenleix)              | October 31, 2021   |
-| Rongrong Zhong    |[rongrong](https://github.com/rongrong)            | October 31, 2021   |
-| Shixuan Fan       |[shixuan-fan](https://github.com/shixuan-fan)      | October 31, 2021   |
-| Jiexi Lin         |[jessesleeping](https://github.com/jessesleeping)  | October 31, 2021   |
-| Leiqing Cai       |[caithagoras](https://github.com/caithagoras)      | October 31, 2021   |
-| Tim Meehan        |[tdcmeehan](https://github.com/tdcmeehan)          | October 31, 2021   |
-| Nezih Yigitbasi   |[nezihyigitbasi](https://github.com/nezihyigitbasi)| October 31, 2021   |
-| Venki Korukanti   |[vkorukanti](https://github.com/vkorukanti)        | October 31, 2021   |
-| Bin Fan           |[apc999](https://github.com/apc999)                | October 31, 2021   |
-
-Legacy members will have terms that expire on October 31, 2021.  Going forward after their term expires, there will be 7 seats open for TSC members.  Their term duration is set below:
-
-| Name | Github | Term Begin       | Term End         | Term Duration |
-| ---- | ------ | ---------------- | ---------------- | ------------- |
-| ???  | ???    | November 1, 2021 | November 1, 2022 | 1 year        |
-| ???  | ???    | November 1, 2021 | May 1, 2023      | 1 year        |
-| ???  | ???    | November 1, 2021 | November 1, 2022 | 1 year        |
-| ???  | ???    | November 1, 2021 | May 1, 2023      | 1 year        |
-| ???  | ???    | November 1, 2021 | November 1, 2022 | 1 year        |
-| ???  | ???    | November 1, 2021 | May 1, 2023      | 1 year        |
-| ???  | ???    | November 1, 2021 | November 1, 2022 | 1 year        |
+e. The voting members and their terms are listed in the [TSC repo](../README.md#members).
 
 f. TSC members will have term limits set.  For the initial election occurring on October 31, 2021, all TSC voting members are eligible to cast a vote for the incoming TSC.  Going forward, only members whose seats are not up for re-election may vote for the incoming class.
 

--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ Everyone must sign the Presto CLA prior to making a contribution. You may either
 
 The current members of the Presto TSC are:
 
-| Name | Github | Affiliation | Term begins | Term ends |
+| Name | Github | Term begins | Term ends | Affiliation |
 | ---- | ------ | ------------|-------------|-----------|
-| Bin Fan  | apc99 | November 1, 2021 | TBD | TBD |
-| James Sun  | highker | November 1, 2021 | TBD | TBD |
-| Rebecca Schlussel | rschlussel | November 1, 2021 | TBD | TBD |
-| Rongrong Zhong | rongrong | November 1, 2021 | TBD | TBD |
-| Tim Meehan  | tdcmeehan | November 1, 2021 | TBD | TBD |
-| Ying Su  | yingsu00 | November 1, 2021 | TBD | TBD |
-| Zhenxiao Luo  | zhenxiao | November 1, 2021 | TBD | TBD |
+| Bin Fan  | apc99 | November 1, 2021 | TBD | Alluxio |
+| James Sun  | highker | November 1, 2021 | TBD | Facebook |
+| Rebecca Schlussel | rschlussel | November 1, 2021 | TBD | Facebook |
+| Rongrong Zhong | rongrong | November 1, 2021 | TBD | Facebook |
+| Tim Meehan  | tdcmeehan | November 1, 2021 | TBD | Facebook |
+| Ying Su  | yingsu00 | November 1, 2021 | TBD | Ahana Cloud |
+| Zhenxiao Luo  | zhenxiao | November 1, 2021 | TBD | Twitter |
 
 TSC membership is open to Presto project committers. Prior to each election, candidates must submit a [self-nomination form](./elections/SELF_NOMINATION_TEMPLATE.md).
 

--- a/README.md
+++ b/README.md
@@ -2,27 +2,6 @@
 
 The Presto TSC will be responsible for all technical oversight of the open source Project.
 
-## 2021 Elections
-
-Elections are now open for all TSC seats.  If you'd like to nominate yourself, please fill out the following template and send to [operations@prestodb.io](mailto:operations@prestodb.io):
-
-```
-# TSC self-nomination
-
-**Name:**
-**Email:**
-
-### Please provide 2-3 sentences on your involvement in the Presto project
-
-### Please provide 3-6 sentences on what you aspire to achieve on the TSC
-
-### Do you currently hold any formal leadership roles within the Presto community?
-
-### Do you commit to attending the monthly TSC calls?
-```
-
-Nominations will be accepted through **Thursday, November 4th, 2021**.
-
 ## Presto Technical Charter
 
 The Presto Technical Charter is located in [CHARTER.md](CHARTER.md)
@@ -47,9 +26,23 @@ Everyone must sign the Presto CLA prior to making a contribution. You may either
 
 ## Members
 
-The TSC voting members are initially the [Project’s Committers](https://github.com/prestodb/presto/wiki/committers), and the current TSC chair is Tim Meehan ([@tdcmeehan](https://github.com/tdcmeehan)). At the inception of the project, the Committers of the Project will be as set forth within the "CONTRIBUTING" file within the Project’s code repository
+The current members of the Presto TSC are:
 
-https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md
+| Name | Github | Affiliation | Term begins | Term ends |
+| ---- | ------ | ------------|-------------|-----------|
+| Bin Fan  | apc99 | November 1, 2021 | TBD | TBD |
+| James Sun  | highker | November 1, 2021 | TBD | TBD |
+| Rebecca Schlussel | rschlussel | November 1, 2021 | TBD | TBD |
+| Rongrong Zhong | rongrong | November 1, 2021 | TBD | TBD |
+| Tim Meehan  | tdcmeehan | November 1, 2021 | TBD | TBD |
+| Ying Su  | yingsu00 | November 1, 2021 | TBD | TBD |
+| Zhenxiao Luo  | zhenxiao | November 1, 2021 | TBD | TBD |
+
+TSC membership is open to Presto project committers. Prior to each election, candidates must submit a [self-nomination form](./elections/SELF_NOMINATION_TEMPLATE.md).
+
+Beginning in 2021, the TSC has seven seats. Per the charter, TSC voting member terms are one year and elections occur semi-annually. To establish the semi-annual cadence, three TSC members will be selected by coin toss to serve an initial 1.5 year term. 
+
+The voting process is described in the [TSC charter](https://github.com/prestodb/tsc/blob/master/CHARTER.md#3-tsc-voting).
 
 ## Policies and procedures
 

--- a/elections/SELF_NOMINATION_TEMPLATE.md
+++ b/elections/SELF_NOMINATION_TEMPLATE.md
@@ -1,0 +1,23 @@
+# TSC Voting Member Self-nomination template
+
+*Please copy and paste the template below the line and submit your self-nomination to the TSC chair and [operations@prestodb.io](mailto:operations@prestodb.io).
+
+At the end of the self-nomination period, all submissions will be compiled into a single public document.*
+
+---
+
+## Your name
+
+# TSC self-nomination
+
+**GitHub username:**
+**Email:**
+
+### Please provide 2-3 sentences on your involvement in the Presto project
+
+### Please provide 3-6 sentences on what you aspire to achieve on the TSC
+
+### Do you currently hold any formal leadership roles within the Presto community?
+
+### Do you commit to attending the monthly TSC calls?
+


### PR DESCRIPTION
This is a housekeeping change to update the results of the most recent election, and add some
explanation about the voting process. It also establishes a permanent location for the
self-nomination template.

It also migrates some administrative information out of the TSC charter text and into the README.
Charter text changes require a separate 2/3 vote, so having this info outside of the charter will
make it easier to update administrative information in the future.

Closes #38 (adding a self-nomination template).
Closes #39 (TSC reached consensus on a different approach).

Signed-off-by: Brian Warner <brian@bdwarner.com>