### PR TITLE
Add agenda regarding improving inactivity time for gh issues

### DIFF
--- a/meetings/2023-01-10.md
+++ b/meetings/2023-01-10.md
@@ -25,6 +25,7 @@ To attend this meeting or propose a topic, edit this page and add your name to t
 
 ### Agenda
 * Tim: code review and voting guidelines: https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines
+* Pratyaksh: Discuss inactivity time for github issue before marking it as stale: https://github.com/prestodb/presto/blob/master/.github/stale.yml
 
 ### Attendance
 #### Voting members
@@ -33,7 +34,7 @@ To attend this meeting or propose a topic, edit this page and add your name to t
 * 
 
 #### Attendees
-*
+* Pratyaksh Sharma | Ahana | India
 ### Action Items
 * N/A
 


### PR DESCRIPTION
Current inactivity time for github issues before marking them as stale and closing them is 2 years. I feel this is too long and this has resulted in a lot of open github issues getting piled up. Too many open issues also give an impression that the community is not very active. Along with decreasing the inactivity time, one time effort from volunteers is needed to bring the number of open issues under control.