### PR TITLE
Hold elections once a year

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ The current members of the Presto TSC are:
 
 | Name | Github | Term begins | Term ends | Affiliation |
 | ---- | ------ | ------------|-------------|-----------|
-| Deepak Majeti  | majetideepak | January 10, 2023 | November 1, 2023 | Ahana Cloud |
-| James Sun  | highker | January 23, 2023 | November 1, 2023 | Meta |
-| Tim Meehan  | tdcmeehan | January 10, 2023 | November 1, 2023 | Ahana Cloud |
-| Ying Su  | yingsu00 | January 10, 2023 | November 1, 2023 | Ahana Cloud |
-| Aditi Pandit | aditi-pandit | June 21, 2023 | November 1, 2023 | Ahana Cloud |
+| Deepak Majeti  | majetideepak | January 10, 2023 | May 1, 2024 | Ahana Cloud |
+| James Sun  | highker | January 23, 2023 | May 1, 2024 | Meta |
+| Tim Meehan  | tdcmeehan | January 10, 2023 | May 1, 2024 | Ahana Cloud |
+| Ying Su  | yingsu00 | January 10, 2023 | May 1, 2024 | Ahana Cloud |
+| Aditi Pandit | aditi-pandit | June 21, 2023 | May 1, 2024 | Ahana Cloud |
 | Rebecca Schlussel | rschlussel | June 21, 2023 | May 1, 2024 | Meta |
 | Beinan Wang | beinan | June 21, 2023 | May 1, 2024 | Alluxio |
 | Zhenxiao Luo  | zhenxiao | June 21, 2023 | May 1, 2024 | Pinterest |


### PR DESCRIPTION
Now that seats don't expire until an election is held to replace the seat, to reduce elections fatigue, I propose we hold elections just once a year.